### PR TITLE
upgrade: pnpm to 8.6.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "version": "4.0.0-alpha.2",
   "homepage": "https://github.com/21S1298001/Mahiron",
   "license": "Apache-2.0",
-  "packageManager": "pnpm@8.1.1",
+  "packageManager": "pnpm@8.6.10",
   "main": "lib/client.js",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
- pnpm is known to break in Node.js 20.x environments.
  - ["ERR_INVALID_THIS" on "pnpm up" in Node 20 · Issue #6424 · pnpm/pnpm](https://github.com/pnpm/pnpm/issues/6424)
- This PR attempts to update the pnpm version to the latest and work around the above issue.
